### PR TITLE
stack trace parsing is broken on google chrome

### DIFF
--- a/docs/js/toc.js
+++ b/docs/js/toc.js
@@ -22,6 +22,9 @@ function contentsOnLoad() {
         toc.appendChild(li);
     }
     dest.appendChild(toc);
+    if (location.hash) {
+      location.hash = location.hash;
+    }
 }
 
 window.onload = contentsOnLoad;

--- a/doctest.js
+++ b/doctest.js
@@ -420,7 +420,7 @@ doctest.JSRunner.prototype.checkResult = function (got, expected) {
   }
   expected = RegExp.escape(expected);
   // Note: .* doesn't match newlines, but [^] matches everything
-  expected = '^' + expected.replace(/\\.\\.\\./g, "[^]*") + '$';
+  expected = '^' + expected.replace(/\\\.\\\.\\\./g, "[^]*") + '$';
   expected = expected.replace(/\n/, '\\n');
   var re = new RegExp(expected);
   return got.search(re) != -1;

--- a/doctest.js
+++ b/doctest.js
@@ -805,6 +805,7 @@ doctest.Spy = function (name, options, extraOptions) {
   this.name = name;
   this.options = options;
   this.called = false;
+  this.calledWait = false;
   this.args = null;
   this.self = null;
   this.argList = [];
@@ -816,6 +817,7 @@ doctest.Spy = function (name, options, extraOptions) {
   this.throwError = options.throwError || null;
   this.func = function () {
     self.called = true;
+    self.calledWait = true;
     self.args = doctest._argsToArray(arguments);
     self.self = this;
     self.argList.push(self.args);
@@ -884,7 +886,11 @@ doctest.Spy.prototype.methods = function (props) {
 doctest.Spy.prototype.wait = function (timeout) {
   var self = this;
   var func = function () {
-    return self.called;
+    var value = self.calledWait;
+    if (value) {
+      self.calledWait = false;
+    }
+    return value;
   };
   func.repr = function () {
     return 'called:'+repr(self);

--- a/doctest.js
+++ b/doctest.js
@@ -790,6 +790,9 @@ doctest.autoSetup._idCount = 0;
 
 doctest.Spy = function (name, options, extraOptions) {
   if (this === window) {
+    if (spies[name]) {
+      return spies[name];
+    }
     return new Spy(name, options);
   }
   name = name || 'spy';


### PR DESCRIPTION
This patch at least lets the tests complete, but doesn't fix underlying stack trace parsin'.
