### PR TITLE
doctest.js broken on webkit due to invocation of eval with non-window this pointer

### DIFF
--- a/doctest.js
+++ b/doctest.js
@@ -1106,7 +1106,9 @@ if (typeof logWarn == 'undefined') {
   logWarn = doctest._consoleFunc('warn');
 }
 
-doctest.eval = window.eval;
+doctest.eval = function(script) {
+  window.eval(script);
+};
 
 doctest.useCoffeeScript = function (options) {
   options = options || {};


### PR DESCRIPTION
title says it all.  Steps to repro?  run a sample on google chrome and notice that it fails with the following:

```
EvalError: The “this” object passed to eval must be the global object from which eval originated.
```

Nice discussion of the issue here: http://perfectionkills.com/global-eval-what-are-the-options/
