### PR TITLE
Fix for IE9

### DIFF
--- a/doctest.js
+++ b/doctest.js
@@ -779,7 +779,7 @@ doctest._reprTrackSave = function () {
 };
 
 doctest._reprTrackRestore = function (point) {
-  doctest._reprTracker.splice(point);
+  doctest._reprTracker.splice(point, doctest._reprTracker.length - point);
 };
 
 doctest._sortedKeys = function (obj) {


### PR DESCRIPTION
On IE9 the splice() command is b0rked.  If there's no explicit howMany parameter, splice behaves as if '0' was provided and removes nothing.  A compatible fix for this is to explicitly specify a howmany argument to splice().

My version of IE9 beta is 9.0.7930.16406

The observed bug is that when an object is sufficiently large (multiline), repr tracking was broken, and you'd get erroneous recursion detection.
