### PR TITLE
Workaround broken splice() function in IE8

### DIFF
--- a/doctest.js
+++ b/doctest.js
@@ -779,7 +779,7 @@ doctest._reprTrackSave = function () {
 };
 
 doctest._reprTrackRestore = function (point) {
-  doctest._reprTracker.splice(point);
+  doctest._reprTracker.splice(point, doctest._reprTracker.length - point);
 };
 
 doctest._sortedKeys = function (obj) {


### PR DESCRIPTION
By adding an explicit howmany parameter.  
