### PR TITLE
Several fixes

### DIFF
--- a/doctest.css
+++ b/doctest.css
@@ -10,23 +10,23 @@ pre {
 
 /* Test block formatting: */
 
-pre.doctest, pre.commenttest {
+pre.doctest, pre.commenttest, pre.test {
     border: 1px solid #999;
     border-radius: 4px;
 }
 
-pre.doctest.doctest-some-failure, pre.commenttest.doctest-some-failure {
+pre.doctest.doctest-some-failure, pre.commenttest.doctest-some-failure, pre.test.doctest-some-failure {
     border: 1px solid #f00;
 }
 
 /* FIXME: it would be nice if this was more obviously styled to show that there
    was more content */
-pre.commenttest.expand-on-failure, pre.doctest.expand-on-failure {
+pre.doctest.expand-on-failure, pre.commenttest.expand-on-failure, pre.test.expand-on-failure {
     max-height: 3em;
     overflow-y: auto;
 }
 
-pre.commenttest.expand-on-failure.doctest-some-failure, pre.doctest.expand-on-failure.doctest-some-failure {
+pre.doctest.expand-on-failure.doctest-some-failure, pre.commenttest.expand-on-failure.doctest-some-failure, pre.test.expand-on-failure.doctest-some-failure {
     max-height: none;
 }
 

--- a/doctest.js
+++ b/doctest.js
@@ -1002,9 +1002,12 @@ HTMLParser.prototype = {
       this.runner.examples.push(ex);
       ex.blockEl = el;
       ex.htmlID = genID('example');
+      if (rawOutput !== '') {
+        rawOutput += '\n';
+      }
       var span = makeElement('span', {id: ex.htmlID, className: 'doctest-example'}, [
         makeElement('span', {className: 'doctest-expr'}, [rawExample + '\n']),
-            makeElement('span', {className: 'doctest-output'}, [rawOutput + '\n'])
+        makeElement('span', {className: 'doctest-output'}, [rawOutput])
         ]);
       ex.htmlSpan = span;
       newChildren.push(span);

--- a/doctest.js
+++ b/doctest.js
@@ -960,7 +960,7 @@ var HTMLParser = exports.HTMLParser = function (runner, containerEl, selector) {
     throw 'Bad/null/missing containerEl';
   }
   this.containerEl = containerEl;
-  this.selector = selector || 'pre.doctest, pre.commenttest';
+  this.selector = selector || 'pre.doctest, pre.commenttest, pre.test';
 };
 
 HTMLParser.prototype = {
@@ -987,7 +987,7 @@ HTMLParser.prototype = {
     var examples;
     if (hasClass(el, 'doctest')) {
       examples = this.parseDoctestEl(el);
-    } else if (hasClass(el, 'commenttest')) {
+    } else if (hasClass(el, 'commenttest') || hasClass(el, 'test')) {
       examples = this.parseCommentEl(el);
     } else {
       throw 'Unknown element class/type';
@@ -1190,7 +1190,7 @@ HTMLParser.prototype = {
 
   fillElement: function (el, text) {
     el.innerHTML = '';
-    if (hasClass(el, 'commenttest')) {
+    if (hasClass(el, 'commenttest') || hasClass(el, 'test')) {
       var texts = this.splitText(text);
       if (texts && texts.length) {
         for (var i=0; i<texts.length; i++) {

--- a/doctest.js
+++ b/doctest.js
@@ -1080,7 +1080,13 @@ HTMLParser.prototype = {
       var example = contents.substr(pos, start-pos);
       var output = comment.value.replace(/^\s*=> ?/, '');
       var orig = comment.type == 'Block' ? '/*' + comment.value + '*/' : '//' + comment.value;
-      result.push([example, output, example, orig]);
+      if (example === '') {
+          result[result.length-1][1] += '\n'+output;
+          result[result.length-1][3] += '\n'+orig;
+      }
+      else {
+        result.push([example, output, example, orig]);
+      }
       pos = end;
     }
     var last = contents.substr(pos, contents.length-pos);

--- a/doctest.js
+++ b/doctest.js
@@ -1160,7 +1160,7 @@ HTMLParser.prototype = {
       result += pattern.substr(0, match.index);
       pattern = pattern.substr(match.index + match[0].length);
       var name = match[1];
-      var restriction = "^[\\w_\\-\\.]+$";;
+      var restriction = "^[\\w_\\-\\.]+$";
       var defaultValue = '';
       if (name.lastIndexOf('|') != -1) {
         defaultValue = name.substr(name.lastIndexOf('|')+1);
@@ -1187,30 +1187,21 @@ HTMLParser.prototype = {
     if (hasClass(el, 'commenttest')) {
       var texts = this.splitText(text);
       if (texts && texts.length) {
-        text = texts[0].body;
-        if (texts[0].header) {
-          h3 = document.createElement('h3');
-          h3.className = 'doctest-section-header';
-          h3.appendChild(document.createTextNode(texts[0].header));
-          el.parentNode.insertBefore(h3, el);
-        }
-        var last = el;
-        for (var i=1; i<texts.length; i++) {
+        for (var i=0; i<texts.length; i++) {
+            if (texts[i].header) {
+                var h3 = document.createElement('h3');
+                h3.className = 'doctest-section-header';
+                h3.appendChild(document.createTextNode(texts[i].header));
+                el.parentNode.insertBefore(h3, null);
+            }
           var pre = document.createElement('pre');
           pre.className = el.className;
           pre.appendChild(document.createTextNode(texts[i].body));
-          last.parentNode.insertBefore(pre, last.nextSibling);
-          if (texts[i].header) {
-            var h3 = document.createElement('h3');
-            h3.className = 'doctest-section-header';
-            h3.appendChild(document.createTextNode(texts[i].header));
-            last.parentNode.insertBefore(h3, last);
-          }
-          last = pre;
+          el.parentNode.insertBefore(pre, null);
         }
       }
     }
-    el.appendChild(doc.createTextNode(text));
+    el.parentNode.removeChild(el);
   },
 
   splitText: function (text) {
@@ -1353,6 +1344,34 @@ var genID = exports.genID = function (prefix) {
 };
 genID._idGen = 1;
 
+function deIndent(text) {
+    var minimum_spaces = 10000;
+    var foo = text.split('\n');
+    var i = 0;
+    var j = 0;
+    var result = '';
+    for (i=0; i < foo.length; i++) {
+        for (j=0; j < foo[i].length && j < minimum_spaces; j++) {
+            if (foo[i][j] != ' ') {
+                if (j < minimum_spaces) {
+                    minimum_spaces = j;
+                }
+                break;
+            }
+        }
+    }
+    if (minimum_spaces == 0) {
+        return text.replace(/^\s+|\s+$/g, '');
+    }
+    for (i=0; i < foo.length; i++) {
+        if (strip(foo[i].substr(0, minimum_spaces)) !== '') {
+            throw 'Deindent failed';
+        }
+        result += foo[i].substr(minimum_spaces) + '\n';
+    }
+    return strip(result);
+}
+
 var getElementText = exports.getElementText = function (el) {
   if (! el) {
     throw('You must pass in an element');
@@ -1367,7 +1386,8 @@ var getElementText = exports.getElementText = function (el) {
       text += getElementText(sub);
     }
   }
-  return text;
+
+  return deIndent(text);
 };
 
 var makeElement = exports.makeElement = function (tagName, attrs, children) {

--- a/doctest.js
+++ b/doctest.js
@@ -1002,12 +1002,9 @@ HTMLParser.prototype = {
       this.runner.examples.push(ex);
       ex.blockEl = el;
       ex.htmlID = genID('example');
-      if (rawOutput !== '') {
-        rawOutput += '\n';
-      }
       var span = makeElement('span', {id: ex.htmlID, className: 'doctest-example'}, [
-        makeElement('span', {className: 'doctest-expr'}, [rawExample + '\n']),
-        makeElement('span', {className: 'doctest-output'}, [rawOutput])
+        makeElement('div', {className: 'doctest-expr'}, [rawExample]),
+        makeElement('div', {className: 'doctest-output'}, [rawOutput])
         ]);
       ex.htmlSpan = span;
       newChildren.push(span);

--- a/doctest.js
+++ b/doctest.js
@@ -209,9 +209,9 @@ var HTMLReporter = exports.HTMLReporter = function (runner, containerEl) {
 HTMLReporter.prototype = {
 
   logSuccess: function (example, got) {
-    var num = parseInt(this.successEl.innerHTML, 10);
+    var num = parseInt(this.successEl.innerHTML.split('/')[0]);
     num++;
-    this.successEl.innerHTML = num+'';
+    this.successEl.innerHTML = num+' / '+this.runner.examples.length;
     addClass(this.successEl, 'doctest-nonzero');
     if (example.htmlSpan) {
       addClass(example.htmlSpan, 'doctest-success');

--- a/examples/examples-2.html
+++ b/examples/examples-2.html
@@ -6,7 +6,7 @@
     <script src="../doctest.js"></script>
     <script type="text/javascript" src="../.resources/toc.js"></script>
     <link rel="stylesheet" type="text/css" href="../.resources/doc.css" />
-    <script src="../esprima/esprima.js"></script>
+    <script src="../.resources/esprima/esprima.js"></script>
     <link rel="stylesheet" href="../doctest.css" type="text/css">
   </head>
   <body class="autodoctest">

--- a/examples/long-running-tests.html
+++ b/examples/long-running-tests.html
@@ -1,0 +1,22 @@
+<!DOCTEST html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Example</title>
+        <script src="../doctest.js"></script>
+        <link rel="stylesheet" type="text/css" href="../.resources/doc.css" />
+        <script src="../.resources/esprima/esprima.js"></script>
+        <link rel="stylesheet" href="../doctest.css" type="text/css">
+    </head>
+    <body class="autodoctest">
+        This is an example of tests that:
+        <ul>
+            <li>wait on long running processes</li>
+            <li>use an external javascript file</li>
+            <li>sections in the tests that will make them run in sequence</li>
+        </ul>
+
+        <pre class="commenttest" href="long-running-tests.js"></pre>
+
+    </body>
+</html>

--- a/examples/long-running-tests.js
+++ b/examples/long-running-tests.js
@@ -1,0 +1,39 @@
+// = SECTION First
+var done = false;
+function foo() {
+    window.setTimeout(function() {
+        done = true;
+        some_var = true;
+    }, 2000);
+    wait(function(){return done;});
+}
+foo();
+print(done);
+// => false
+
+// = SECTION check output 1
+print(done);
+// => true
+print(some_var);
+// => true
+
+// = SECTION Second
+done = false;
+function foo2() {
+    window.setTimeout(function() {
+        done = true;
+        another_var = true;
+    }, 2000);
+    wait(function(){return done;});
+}
+foo2();
+print(done);
+// => false
+
+// = SECTION check output 2
+print(done);
+// => true
+print(another_var);
+// => true
+print(some_var);
+// => true


### PR DESCRIPTION
- Prettier output (for example, fixed so that the output looks more like the code you write, avoiding extra newlines at the end of the pre-block in some cases)
- Fixed // SECTION sections. They used to output the headers below the sections instead of above where you write them.
- Show total number of tests while running tests
- Continuations for expected output (fixes  #31)
- Switch to class="test" instead of class="commenttest" (fixes #22)
