### PR TITLE
Node test runner

### DIFF
--- a/bin/doctest
+++ b/bin/doctest
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+var path = require('path');
+var fs = require('fs');
+var root = path.join(path.dirname(fs.realpathSync(__filename)), '..');
+
+var doctest = require(root + '/doctest');
+
+var runner = new doctest.Runner({Reporter: doctest.ConsoleReporter});
+var parser = new doctest.TextParser.fromFile(runner, process.argv[2]);
+parser.parse();
+runner.run();
+var reporter = runner.reporter;
+console.log('Successes:', reporter.successes);
+console.log('Failures:', reporter.failures);
+if ((! reporter.successes) || reporter.failures) {
+  // Set exit code to number of failures (if any). It gives a nice failures
+  // summary when running under make. E.g.: `make: *** [doctest] Error 2`
+  process.exit(reporter.failures || 1);
+}

--- a/bin/doctest
+++ b/bin/doctest
@@ -7,9 +7,11 @@ var root = path.join(path.dirname(fs.realpathSync(__filename)), '..');
 var doctest = require(root + '/doctest');
 
 var runner = new doctest.Runner({Reporter: doctest.ConsoleReporter});
+runner.globs = runner.evalInit();
 var parser = new doctest.TextParser.fromFile(runner, process.argv[2]);
 parser.parse();
 runner.run();
+
 var reporter = runner.reporter;
 console.log('Successes:', reporter.successes);
 console.log('Failures:', reporter.failures);

--- a/doctest.js
+++ b/doctest.js
@@ -51,7 +51,7 @@ Example.prototype = {
     this.consoleOutput = [];
     var globs = this.runner.evalInit();
     try {
-      this.result = this.runner.evaller(this.expr, globs);
+      this.result = this.runner.evaller(this.expr, globs, this.filename);
     } catch (e) {
       if (e['doctest.abort']) {
         return;
@@ -664,7 +664,9 @@ Runner.prototype = {
   },
 
   evalInit: function () {
-    var self = this;
+    if (typeof this.globs != "undefined") {
+      return this.globs;
+    }
     this.logGrouped = false;
     this._abortCalled = false;
     var globs = {
@@ -695,7 +697,9 @@ Runner.prototype = {
           }
         }
       }
-      return globs;
+      var context = require('vm').Script.createContext();
+      extend(context, globs);
+      return context;
     } else {
       extend(console, consoleOverwrites);
       window.onerror = this.windowOnerror;
@@ -817,14 +821,45 @@ Runner.prototype = {
     }
   },
 
-  evaller: function (expr, context) {
+  evaller: function (expr, context, filename) {
     var e = eval;
     var result;
     if (context) {
-      if (typeof global != "undefined") {
-        extend(global, context);
+      if (typeof window == "undefined") {
         var vm = require('vm');
-        vm.runInThisContext(expr);
+
+        if (! (context instanceof vm.Script.createContext().constructor)) {
+            throw "context must be created with vm.Script.createContext()";
+        }
+
+        // Prepare context to evaluate `expr` in. Mostly follows CoffeeScript
+        // [eval function](http://git.io/coffee-script-eval).
+        context.global = context.root = context.GLOBAL = context;
+        context.__filename = typeof filename != "undefined" ? filename : __filename;
+        context.__dirname = require('path').dirname(context.__filename);
+        context.module = module;
+        context.require = require;
+
+        // Set `module.filename` to script file name and evaluate the script.
+        // Now, if the script executes `require('./something')`, it will look
+        // up `'./something'` relative to script path.
+        //
+        // We restore `module.filename` afterwards, because `module` object
+        // is reused. The other approach is to create a new `module` instance.
+        // CoffeeScript [eval][1] [works this way][2]. Unfortunately it
+        // [uses private Node API][3] to do it.
+        //
+        // [1]: http://git.io/coffee-script-eval
+        // [2]: https://github.com/jashkenas/coffee-script/pull/1487
+        // [3]: http://git.io/coffee-script-eval-comment
+        var prevfilename = module.filename;
+        module.filename = context.__filename;
+        try {
+          vm.runInContext(expr, context, context.__filename);
+        } finally {
+            module.filename = prevfilename;
+        }
+
       } else {
         with (context) {
           result = eval(expr);
@@ -932,8 +967,10 @@ Runner.prototype = {
   examples: null,
   Example: Example,
   exampleOptions: null,
-  makeExample: function (text, expected) {
-    return new this.Example(this, text, expected, this.exampleOptions);
+  makeExample: function (text, expected, filename) {
+    var options = {filename: filename};
+    extend(options, this.exampleOptions);
+    return new this.Example(this, text, expected, options);
   },
   matcher: null,
   Matcher: Matcher,
@@ -1254,7 +1291,7 @@ HTMLParser.prototype = {
 
 };
 
-var TextParser = exports.TextParser = function (runner, text) {
+var TextParser = exports.TextParser = function (runner, text, filename) {
   if (typeof esprima == "undefined") {
     if (typeof require != "undefined") {
       esprima = require("./esprima/esprima.js");
@@ -1264,6 +1301,7 @@ var TextParser = exports.TextParser = function (runner, text) {
   }
   this.runner = runner;
   this.text = text;
+  this.filename = filename;
 };
 
 TextParser.fromFile = function (runner, filename) {
@@ -1275,7 +1313,7 @@ TextParser.fromFile = function (runner, filename) {
   }
   var fs = require('fs');
   var text = fs.readFileSync(filename, 'UTF-8');
-  return new TextParser(runner, text);
+  return new TextParser(runner, text, filename);
 };
 
 TextParser.prototype = {
@@ -1296,13 +1334,13 @@ TextParser.prototype = {
       var end = comment.range[1];
       var example = this.text.substr(pos, start-pos);
       var output = comment.value.replace(/^\s*=>\s*/, '');
-      var ex = this.runner.makeExample(example, output);
+      var ex = this.runner.makeExample(example, output, this.filename);
       this.runner.examples.push(ex);
       pos = end;
     }
     var last = this.text.substr(pos, this.text.length-pos);
     if (strip(last)) {
-      this.runner.examples.push(this.runner.makeExample(last, ''));
+      this.runner.examples.push(this.runner.makeExample(last, '', this.filename));
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "doctest",
-  "version": "0.3",
+  "name": "doctestjs",
+  "version": "0.3.0",
   "main": "doctest",
+  "bin": {
+    "doctest": "./bin/doctest"
+  },
   "description": "Example-based testing framework",
   "keywords": [],
   "author": {


### PR DESCRIPTION
I've implemented `doctest` runner (issue #34). It can be used like this:

```
 $ cd ~/doctestjs
 $ npm link
 $ cd ~/your-project
 $ doctest test.js
 ...
 Successes: 10
 Failures: 0
```

The output is the same as in `node-example.js`. But to make it usable in practice I had to fix several related bugs:
- `require` now works inside evaluated scripts, and also resolves relative imports correctly. This was the most annoying bug to fix. See commits for details.
- changed package version from `0.3` to `0.3.0`, to make npm happy. Even `npm link` didn't work without this change.
- renamed package name from "doctest" to "doctestjs", because "doctest" is already taken on npm. I haven't run `npm publish` yet. Feel free to change the name if you want (e.g. "doctest.js") and publish it.

Commits are somewhat verbose, because I made several unsuccessful attempts to fix `require` bug. I can collapse commits if neccessary.
