### PR TITLE
disable undefined XHR warning under Node

### DIFF
--- a/doctest.js
+++ b/doctest.js
@@ -614,7 +614,8 @@ repr.ReprClass.prototype = {
      "arrayRepr"
     ],
     [function (o) {
-       return o instanceof XMLHttpRequest;
+       return typeof XMLHttpRequest !== 'undefined' && o instanceof XMLHttpRequest;
+
      },
      'xhrRepr'
     ]


### PR DESCRIPTION
This gets rid of the warning:

```
Error stringifying object: [ReferenceError: XMLHttpRequest is not defined]
```

Discussion: https://github.com/shamrin/doctestjs/commit/4e584d8b9521184e1a2411dc7d9498c781a36fd2#commitcomment-2995270
