### PR TITLE
bower support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .resources/_build
+bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "doctestjs",
+  "version": "0.3.0",
+  "homepage": "http://doctestjs.org/",
+  "authors": [
+    "Ian Bicking <ian@ianbicking.org>"
+  ],
+  "description": "Example-based testing framework",
+  "main": "doctest",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "**/*.html",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -15,5 +15,8 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "devDependencies": {
+    "esprima": "~1.0.4"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "test",
     "tests"
   ],
-  "devDependencies": {
+  "dependencies": {
     "esprima": "~1.0.4"
   }
 }


### PR DESCRIPTION
Since I use bower for everything, I think it's a shame that doctestjs doesn't support bower. I haven't publish doctestjs to the bower registry but everything is ready to be published. I have tested the package locally.
Just do `bower register doctestjs https://github.com/ianb/doctestjs.git`
